### PR TITLE
Issues #2 ルーター機能STEP1終了

### DIFF
--- a/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/ReelsViewHandler.java
+++ b/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/ReelsViewHandler.java
@@ -1,0 +1,30 @@
+package com.github.reels_project.reels.faces.router;
+
+import javax.faces.application.ViewHandler;
+import javax.faces.application.ViewHandlerWrapper;
+import javax.faces.context.FacesContext;
+
+public class ReelsViewHandler extends ViewHandlerWrapper{
+	protected ViewHandler parent;
+
+	public ReelsViewHandler(ViewHandler parent) {
+		super();
+		this.parent = parent;
+	}
+
+	@Override
+	public ViewHandler getWrapped() {
+		return parent;
+	}
+
+	@Override
+	public String getActionURL(final FacesContext context, final String viewId){
+		//ここが呼ばれる場合getBookmarkableURLは呼ばれない。FormまたはoutcomeTargetXXから呼ばれる。
+		String result = parent.getActionURL(context, viewId);
+		//TODO 設定から取得する
+		result = result.replace("/views", "").replace(".xhtml", "");
+		//FIXME h:linkに直接外向きURLを指定するとDisableになる
+		//FIXME NavigationHandlerでNavigationCaseがあるかどうかで判断している？
+		return result;
+	}
+}

--- a/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/RouterConfiguration.java
+++ b/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/RouterConfiguration.java
@@ -1,0 +1,60 @@
+package com.github.reels_project.reels.faces.router;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RouterConfiguration {
+	//JSFはCSSの世界まで行けないのであえてassets固定にする
+	private static final String DEFAULT_ASSETS_PATH = "assets";
+	private static final String DEFAULT_VIEWS_PATH = "views";
+	//TODO パラメーター分解後にくっつけるイメージ
+	private static final String DEFAULT_EXTENSION = ".xhtml";
+	private static final List<String> DEFAULT_RESOURCE_TYPES = Arrays.asList(new String[]{"js","css","jpeg","jpg","png","gif"});
+
+	private boolean enable;
+	private String assetsPath;
+	private String viewsPath;
+	private String extension;
+	private List<String> resourceTypes;
+	
+	public RouterConfiguration() {
+		this.enable = true;
+		this.assetsPath = DEFAULT_ASSETS_PATH;
+		this.viewsPath = DEFAULT_VIEWS_PATH;
+		this.extension = DEFAULT_EXTENSION;
+		this.resourceTypes = DEFAULT_RESOURCE_TYPES;
+	}
+
+	public boolean isEnable() {
+		return enable;
+	}
+
+	public void setEnable(boolean enable) {
+		this.enable = enable;
+	}
+
+	public String getAssetsPath() {
+		return assetsPath;
+	}
+	public void setAssetsPath(String assetsPath) {
+		this.assetsPath = assetsPath;
+	}
+	public String getViewsPath() {
+		return viewsPath;
+	}
+	public void setViewsPath(String viewsPath) {
+		this.viewsPath = viewsPath;
+	}
+	public String getExtension() {
+		return extension;
+	}
+	public void setExtension(String extension) {
+		this.extension = extension;
+	}
+	public List<String> getResourceTypes() {
+		return resourceTypes;
+	}
+	public void setResourceTypes(List<String> resourceTypes) {
+		this.resourceTypes = resourceTypes;
+	}
+}

--- a/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/Routing.java
+++ b/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/Routing.java
@@ -1,0 +1,81 @@
+package com.github.reels_project.reels.faces.router;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * FIXME 作りがあまりかっこよくない
+ * @author Takahiko Sato
+ *
+ */
+public class Routing {
+
+	private static final Pattern JSESSIONID_PATTERN = Pattern.compile("(?i)^(.*);jsessionid=[\\w\\.\\-]+(.*)");
+	private static final String JSESSIONID_REPLACEMENT = "$1$2";
+
+	private final Pattern RESOURCE_PATTERN;
+
+	private final RouterConfiguration routerConfiguration;
+	private final String originalURL;
+	private final String contextPath;
+	
+	public Routing(HttpServletRequest request,RouterConfiguration routerConfiguration) {
+		this.routerConfiguration = Objects.requireNonNull(routerConfiguration);
+		
+		String orig = Objects.requireNonNull(request).getRequestURI();
+		Matcher sessionIdMatcher = JSESSIONID_PATTERN.matcher(orig);
+		if (sessionIdMatcher.matches()){
+			orig = sessionIdMatcher.replaceFirst(JSESSIONID_REPLACEMENT);
+		}
+		this.originalURL = orig;
+		this.contextPath = request.getContextPath();
+		
+		this.RESOURCE_PATTERN = Pattern.compile(
+			String.format(
+				".+\\.(%s).*",
+				routerConfiguration.getResourceTypes().stream()
+				.map(s->s.trim())
+				.collect(Collectors.joining("|"))
+			),Pattern.CASE_INSENSITIVE);
+		
+		//TODO 個別ルーティングのときのみパスパラメーター有効
+//		queryMap = new HashMap<>();
+//
+//		Pattern p = Pattern.compile("\\{\\{([^\\}]+)\\}\\}");
+//		Matcher m = p.matcher("/hoge/{{piyo}}//{{hage}}");
+//		while(m.find()){
+//			System.out.println(m.group(1));
+//		}
+		
+	}
+	
+	public boolean isAssetsRequest(){
+		String url = originalURL.replace(contextPath, "");
+		return url.startsWith("/" + routerConfiguration.getAssetsPath());
+	}
+	
+	public boolean isResourceRequest(){
+		return !isAssetsRequest() && RESOURCE_PATTERN.matcher(originalURL).matches();
+	}
+	
+	public boolean isTransrated(){
+		return originalURL.contains(routerConfiguration.getViewsPath());
+	}
+	
+	public String from(){
+		return originalURL.replace(contextPath, "");
+	}
+	
+	public String to(){
+		if(isAssetsRequest() || isResourceRequest() || isTransrated()){
+			return originalURL.replace(contextPath, "");
+		}
+		String orig = originalURL;
+		//パラメーターはHTTPServletRequestのものが使用されるため考慮不要
+		return "/" + routerConfiguration.getViewsPath() + orig.replace(contextPath, "") + routerConfiguration.getExtension();
+	}
+}

--- a/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/RoutingFilter.java
+++ b/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/RoutingFilter.java
@@ -1,0 +1,46 @@
+package com.github.reels_project.reels.faces.router;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+@WebFilter(urlPatterns={"/*"})
+public class RoutingFilter implements Filter{
+	
+	private RouterConfiguration routerConfiguration;
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		// TODO グローバルルーティング設定を読み込む
+		routerConfiguration = new RouterConfiguration();
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		
+		HttpServletRequest req = (HttpServletRequest)request;
+		
+		Routing routing = new Routing(req,routerConfiguration);
+		//アセットリクエストでない。JSFリソースでない。
+		if(routerConfiguration.isEnable() && !routing.isAssetsRequest() && !routing.isResourceRequest() && !routing.isTransrated()){
+			//リライト対象
+			req.getRequestDispatcher(routing.to()).forward(request, response);
+		}else{
+			//リソースまたはリライト後？
+			chain.doFilter(request, response);
+		}
+	}
+	
+	@Override
+	public void destroy() {
+		// TODO 後処理:ログかな?
+	}
+}

--- a/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/package-info.java
+++ b/reels-faces/src/main/java/com/github/reels_project/reels/faces/router/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * 
+ * URLリライトに関する機能を提供します
+ * @author Takahiko Sato
+ *
+ */
+package com.github.reels_project.reels.faces.router;

--- a/reels-faces/src/main/resources/META-INF/faces-config.xml
+++ b/reels-faces/src/main/resources/META-INF/faces-config.xml
@@ -7,5 +7,6 @@
     version="2.1">
     <application>
       <action-listener>com.github.reels_project.reels.faces.application.ReelsActionListener</action-listener>
+      <view-handler>com.github.reels_project.reels.faces.router.ReelsViewHandler</view-handler>
     </application>
 </faces-config>

--- a/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/RoutingFilterTest.java
+++ b/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/RoutingFilterTest.java
@@ -1,0 +1,112 @@
+package com.github.reels_project.reels.faces.router;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class RoutingFilterTest {
+	
+	private HttpServletRequest request;
+	private HttpServletResponse response;
+	private RequestDispatcher requestDispatcher;
+	private FilterConfig filterConfig;
+	private FilterChain chain;
+	
+	@Before
+	public void before(){
+		request = mock(HttpServletRequest.class);
+		response = mock(HttpServletResponse.class);
+		requestDispatcher = mock(RequestDispatcher.class);
+		filterConfig = mock(FilterConfig.class);
+		chain = mock(FilterChain.class);
+	}
+	
+	@Test
+	public void routingTarget(){
+		when(request.getRequestURI()).thenReturn("/context/product/list");
+		when(request.getContextPath()).thenReturn("/context");
+		ArgumentCaptor<String> viewIdCapture = ArgumentCaptor.forClass(String.class);
+		when(request.getRequestDispatcher(viewIdCapture.capture())).thenReturn(requestDispatcher);
+		
+		RoutingFilter filter = new RoutingFilter();
+		try {
+			filter.init(filterConfig);
+			filter.doFilter(request, response, chain);
+			
+			
+			verify(request).getRequestDispatcher(viewIdCapture.capture());
+			verify(requestDispatcher).forward(request, response);
+			
+			assertThat(viewIdCapture.getValue(), is("/views/product/list.xhtml"));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		} 
+	}
+	
+	@Test
+	public void routingNonTargetAssets(){
+		when(request.getRequestURI()).thenReturn("/context/assets/list");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		RoutingFilter filter = new RoutingFilter();
+		try {
+			filter.init(filterConfig);
+			filter.doFilter(request, response, chain);
+			
+			verify(chain).doFilter(request, response);
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		} 
+	}
+	
+	@Test
+	public void routingNonTargetResources(){
+		when(request.getRequestURI()).thenReturn("/context/assets/list.css");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		RoutingFilter filter = new RoutingFilter();
+		try {
+			filter.init(filterConfig);
+			filter.doFilter(request, response, chain);
+			
+			verify(chain).doFilter(request, response);
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		} 
+	}
+	
+	@Test
+	public void routingNonTargetTransrated(){
+		when(request.getRequestURI()).thenReturn("/context/views/assets/list.xhtml");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		RoutingFilter filter = new RoutingFilter();
+		try {
+			filter.init(filterConfig);
+			filter.doFilter(request, response, chain);
+			
+			verify(chain).doFilter(request, response);
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		} 
+	}
+	
+}

--- a/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/RoutingTest.java
+++ b/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/RoutingTest.java
@@ -1,0 +1,102 @@
+package com.github.reels_project.reels.faces.router;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class RoutingTest {
+	
+	private HttpServletRequest request;
+	
+	@Before
+	public void before(){
+		request = mock(HttpServletRequest.class);
+	}
+	
+	@Test
+	public void routing(){
+		when(request.getRequestURI()).thenReturn("/context/product/list");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		Routing r = new Routing(request, new RouterConfiguration());
+		
+		assertThat(r.from(), is("/product/list"));
+		assertThat(r.to(), is("/views/product/list.xhtml"));
+		assertFalse(r.isAssetsRequest());
+		assertFalse(r.isResourceRequest());
+		assertFalse(r.isTransrated());
+	}
+	
+	@Test
+	public void routing_jsessionidIgnore(){
+		when(request.getRequestURI()).thenReturn("/context/product/list;jsessionid=ABCDDDD");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		Routing r = new Routing(request, new RouterConfiguration());
+		
+		assertThat(r.from(), is("/product/list"));
+		assertThat(r.to(), is("/views/product/list.xhtml"));
+		assertFalse(r.isAssetsRequest());
+		assertFalse(r.isResourceRequest());
+		assertFalse(r.isTransrated());
+	}
+	
+	@Test
+	public void transratedCase(){
+		when(request.getRequestURI()).thenReturn("/context/views/product/list.xhtml");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		Routing r = new Routing(request, new RouterConfiguration());
+		
+		assertThat(r.from(), is("/views/product/list.xhtml"));
+		assertThat(r.to(), is("/views/product/list.xhtml"));
+		assertFalse(r.isAssetsRequest());
+		assertFalse(r.isResourceRequest());
+		assertTrue(r.isTransrated());
+	}
+	
+	@Test
+	public void assetRequetCase(){
+		when(request.getRequestURI()).thenReturn("/context/assets/hoge");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		Routing r = new Routing(request, new RouterConfiguration());
+		
+		assertThat(r.from(), is("/assets/hoge"));
+		assertThat(r.to(), is("/assets/hoge"));
+		assertTrue(r.isAssetsRequest());
+		assertFalse(r.isResourceRequest());
+		assertFalse(r.isTransrated());
+	}
+	
+	@Test
+	public void resourceRequetCase(){
+		when(request.getRequestURI()).thenReturn("/context/javax.faces.resources/hoge.js");
+		when(request.getContextPath()).thenReturn("/context");
+		
+		Routing r = new Routing(request, new RouterConfiguration());
+		
+		assertThat(r.from(), is("/javax.faces.resources/hoge.js"));
+		assertThat(r.to(), is("/javax.faces.resources/hoge.js"));
+		assertFalse(r.isAssetsRequest());
+		assertTrue(r.isResourceRequest());
+		assertFalse(r.isTransrated());
+	}
+	
+	@Test(expected=NullPointerException.class)
+	public void constructor_requestIsNull(){
+		new Routing(null, new RouterConfiguration());
+	}
+	
+	@Test(expected=NullPointerException.class)
+	public void constructor_requestIsConfig(){
+		new Routing(request, null);
+	}
+	
+	
+}

--- a/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/ViewHandlerTest.java
+++ b/reels-faces/src/test/java/com/github/reels_project/reels/faces/router/ViewHandlerTest.java
@@ -1,0 +1,35 @@
+package com.github.reels_project.reels.faces.router;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import javax.faces.application.ViewHandler;
+import javax.faces.context.FacesContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ViewHandlerTest {
+	
+	private FacesContext facesContext;
+	private ViewHandler viewHandler;
+	
+	@Before
+	public void before(){
+		facesContext = mock(FacesContext.class);
+		viewHandler = mock(ViewHandler.class);
+	}
+	
+	@Test
+	public void getActionURL(){
+		when(viewHandler.getActionURL(any(), anyString())).thenReturn("/context/views/product/list.xhtml");
+		
+		String url = new ReelsViewHandler(viewHandler).getActionURL(facesContext, "list.xhtml");
+		
+		assertNotNull(url);
+		assertThat(url, is("/context/product/list"));
+	}
+	
+	
+}


### PR DESCRIPTION
Reelsデフォルト設定として
- `[webContent]/views`にfaceletsファイルを置く
- 外部URLから内部URLに変換する際に`views`と`.xhtml`を付加する
  - `/context/product/list` => `/context/views/product/list.xhtml`
- ボタンやリンクなどのURLは逆に外部URLに変換する

STEP2では個別ルーティング及びパスパラメーターの対応を行う
